### PR TITLE
Fix vrmonitor restart error for non-standard Steam install paths

### DIFF
--- a/bin/win64/restartvrserver.bat
+++ b/bin/win64/restartvrserver.bat
@@ -10,4 +10,8 @@ taskkill /im vrdashboard.exe /f >nul 2>nul
 taskkill /im vrserver.exe /f >nul 2>nul
 
 REM Start vrmonitor.exe
-start "" "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\bin\win32\vrmonitor.exe"
+SET steamvrpath="\steamapps\common\SteamVR\tools\bin\win32\vrmonitor.exe"
+FOR /F "usebackq tokens=2,* skip=2" %%L IN (
+    `reg query "HKCU\SOFTWARE\Valve\Steam" /v SteamPath`
+) DO SET steampath=%%M
+start "" %steampath%%steamvrpath%


### PR DESCRIPTION
On systems with non-standard Steam install paths, attempting to restart vrmonitor would result in an error. This PR addresses that error by using the `HKCU\SOFTWARE\Valve\Steam\SteamPath` registry value to find the vrmonitor.exe application, rather than hard-coding that path in the batch file.
