### PR TITLE
Move the push-to-toggle y axis adjustment to a new Accessibility Tools tab.

### DIFF
--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -24,7 +24,8 @@ SOURCES += src/main.cpp\
 		src/tabcontrollers/ReviveTabController.cpp \
 		src/tabcontrollers/UtilitiesTabController.cpp \
 		src/tabcontrollers/audiomanager/AudioManagerWindows.cpp \
-		src/tabcontrollers/PttController.cpp
+		src/tabcontrollers/PttController.cpp \
+		src/tabcontrollers/AccessibilityTabController.cpp
 
 HEADERS  += src/overlaycontroller.h \
 		src/logging.h \
@@ -39,7 +40,8 @@ HEADERS  += src/overlaycontroller.h \
 		src/tabcontrollers/UtilitiesTabController.h \
 		src/tabcontrollers/AudioManager.h \
 		src/tabcontrollers/audiomanager/AudioManagerWindows.h \
-		src/tabcontrollers/PttController.h
+		src/tabcontrollers/PttController.h \
+		src/tabcontrollers/AccessibilityTabController.h
 
 INCLUDEPATH += third-party/openvr/include \
 			third-party/easylogging++

--- a/bin/win64/res/qml/AccessibilityPage.qml
+++ b/bin/win64/res/qml/AccessibilityPage.qml
@@ -1,0 +1,179 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import matzman666.advsettings 1.0
+
+
+
+MyStackViewPage {
+    headerText: "Accessibility Tools"
+
+    PttControllerConfigDialog {
+        id: pttControllerConfigDialog
+        pttControllerConfigClass: AccessibilityTabController
+    }
+
+    content: ColumnLayout {
+        spacing: 92
+
+        GroupBox {
+            Layout.fillWidth: true
+
+            label: MyText {
+                leftPadding: 10
+                text: "Adjust Player Height"
+                bottomPadding: -10
+            }
+            background: Rectangle {
+                color: "transparent"
+                border.color: "#ffffff"
+                radius: 8
+            }
+
+            ColumnLayout {
+                anchors.fill: parent
+
+                Rectangle {
+                    color: "#ffffff"
+                    height: 1
+                    Layout.fillWidth: true
+                    Layout.bottomMargin: 5
+                }
+
+                RowLayout {
+                    MyPushButton2 {
+                        Layout.preferredWidth: 40
+                        text: "-"
+                        onClicked: {
+                            accessibilityMoveYSlider.decrease()
+                        }
+                    }
+
+                    MySlider {
+                        id: accessibilityMoveYSlider
+                        from: 0
+                        to: 1.5
+                        stepSize: 0.05
+                        value: 0.0
+                        Layout.fillWidth: true
+                        onPositionChanged: {
+                            var val = this.from + ( this.position  * (this.to - this.from))
+                            accessibilityMoveYText.text = val.toFixed(2)
+                        }
+                        onValueChanged: {
+                            AccessibilityTabController.heightOffset = this.value.toFixed(2)
+                        }
+                    }
+
+                    MyPushButton2 {
+                        Layout.preferredWidth: 40
+                        text: "+"
+                        onClicked: {
+                            accessibilityMoveYSlider.increase()
+                        }
+                    }
+
+                    MyTextField {
+                        id: accessibilityMoveYText
+                        text: "0.00"
+                        keyBoardUID: 700
+                        Layout.preferredWidth: 140
+                        Layout.leftMargin: 10
+                        Layout.rightMargin: 10
+                        horizontalAlignment: Text.AlignHCenter
+                        function onInputEvent(input) {
+                            var val = parseFloat(input)
+                            if (!isNaN(val) && val >= accessibilityMoveYSlider.from && val <= accessibilityMoveYSlider.to) {
+                                accessibilityMoveYSlider.value = val.toFixed(2);
+                            }
+                            text = AccessibilityTabController.heightOffset.toFixed(2)
+                        }
+                    }
+                }
+
+                RowLayout {
+                    MyToggleButton {
+                        id: heightOffsetPttEnabledToggle
+                        Layout.preferredWidth: 260
+                        text: "Push-to-Toggle:"
+                        onClicked: {
+                            AccessibilityTabController.pttEnabled = checked
+                        }
+                    }
+                    MyToggleButton {
+                        id: heightOffsetPttLeftControllerToggle
+                        text: "Left Controller"
+                        onClicked: {
+                            AccessibilityTabController.setPttLeftControllerEnabled(checked, false)
+                        }
+                    }
+                    MyPushButton {
+                        text: "Configure"
+                        onClicked: {
+                            pttControllerConfigDialog.openPopup(0)
+                        }
+                    }
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                    MyToggleButton {
+                        id: heightOffsetPttRightControllerToggle
+                        text: "Right Controller"
+                        onClicked: {
+                            AccessibilityTabController.setPttRightControllerEnabled(checked, false)
+                        }
+                    }
+                    MyPushButton {
+                        text: "Configure"
+                        onClicked: {
+                            pttControllerConfigDialog.openPopup(1)
+                        }
+                    }
+                }
+            }
+        }
+
+        Item { Layout.fillHeight: true; Layout.fillWidth: true}
+
+        MyPushButton {
+            id: accessibilityResetButton
+            Layout.preferredWidth: 250
+            text: "Reset"
+            onClicked: {
+                AccessibilityTabController.reset()
+            }
+        }
+
+        Component.onCompleted: {
+            var heightOffsetFormatted = AccessibilityTabController.heightOffset.toFixed(2)
+            accessibilityMoveYText.text = heightOffsetFormatted
+            accessibilityMoveYSlider.value = heightOffsetFormatted
+            heightOffsetPttEnabledToggle.checked = AccessibilityTabController.pttEnabled
+            heightOffsetPttLeftControllerToggle.checked = AccessibilityTabController.pttLeftControllerEnabled
+            heightOffsetPttRightControllerToggle.checked = AccessibilityTabController.pttRightControllerEnabled
+        }
+
+        Connections {
+            target: AccessibilityTabController
+            onHeightOffsetChanged: {
+                var heightOffsetFormatted = AccessibilityTabController.heightOffset.toFixed(2)
+                accessibilityMoveYText.text = heightOffsetFormatted
+                accessibilityMoveYSlider.value = heightOffsetFormatted
+            }
+            onPttEnabledChanged: {
+                heightOffsetPttEnabledToggle.checked = AccessibilityTabController.pttEnabled
+            }
+            onPttActiveChanged: {
+
+            }
+            onPttLeftControllerEnabledChanged: {
+                heightOffsetPttLeftControllerToggle.checked = AccessibilityTabController.pttLeftControllerEnabled
+            }
+            onPttRightControllerEnabledChanged: {
+                heightOffsetPttRightControllerToggle.checked = AccessibilityTabController.pttRightControllerEnabled
+            }
+        }
+
+    }
+
+}

--- a/bin/win64/res/qml/PlayspacePage.qml
+++ b/bin/win64/res/qml/PlayspacePage.qml
@@ -8,11 +8,6 @@ import matzman666.advsettings 1.0
 MyStackViewPage {
     headerText: "Play Space Settings"
 
-    PttControllerConfigDialog {
-        id: pttControllerConfigDialog
-        pttControllerConfigClass: MoveCenterTabController
-    }
-
     content: ColumnLayout {
         spacing: 18
 
@@ -68,10 +63,10 @@ MyStackViewPage {
                         }
                     }
 
-                    MyTextField {
+					MyTextField {
                         id: playSpaceMoveXText
                         text: "0.00"
-                        keyBoardUID: 101
+						keyBoardUID: 101
                         Layout.preferredWidth: 140
                         Layout.leftMargin: 10
                         Layout.rightMargin: 10
@@ -270,79 +265,9 @@ MyStackViewPage {
             }
         }
 
-        GroupBox {
-            Layout.fillWidth: true
-
-            label: MyText {
-                leftPadding: 10
-                text: "Push-to-Toggle Y-Axis Offset"
-                bottomPadding: -10
-            }
-
-            background: Rectangle {
-                color: "transparent"
-                border.color: "#ffffff"
-                radius: 8
-            }
-
-            ColumnLayout {
-                anchors.fill: parent
-
-                Rectangle {
-                    color: "#ffffff"
-                    height: 1
-                    Layout.fillWidth: true
-                    Layout.bottomMargin: 5
-                }
-
-                ColumnLayout {
-                    RowLayout {
-                        MyToggleButton {
-                            id: offsetYPttEnabledToggle
-                            Layout.preferredWidth: 260
-                            text: "Enabled"
-                            onClicked: {
-                                MoveCenterTabController.pttEnabled = checked
-                            }
-                        }
-                        MyToggleButton {
-                            id: offsetYPttLeftControllerToggle
-                            text: "Left Controller"
-                            onClicked: {
-                                MoveCenterTabController.setPttLeftControllerEnabled(checked, false)
-                            }
-                        }
-                        MyPushButton {
-                            text: "Configure"
-                            onClicked: {
-                                pttControllerConfigDialog.openPopup(0)
-                            }
-                        }
-                        Item {
-                            Layout.fillWidth: true
-                        }
-                        MyToggleButton {
-                            id: offsetYPttRightControllerToggle
-                            text: "Right Controller"
-                            onClicked: {
-                                MoveCenterTabController.setPttRightControllerEnabled(checked, false)
-                            }
-                        }
-                        MyPushButton {
-                            text: "Configure"
-                            onClicked: {
-                                pttControllerConfigDialog.openPopup(1)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         MyToggleButton {
             id: playspaceAdjustChaperoneToggle
             text: "Adjust Chaperone"
-            Layout.preferredWidth: 270
             onCheckedChanged: {
                 MoveCenterTabController.adjustChaperone = this.checked
             }
@@ -380,9 +305,6 @@ MyStackViewPage {
             } else {
                 playspaceModeText.text = "Unknown(" + MoveCenterTabController.trackingUniverse + ")"
             }
-            offsetYPttEnabledToggle.checked = MoveCenterTabController.pttEnabled
-            offsetYPttLeftControllerToggle.checked = MoveCenterTabController.pttLeftControllerEnabled
-            offsetYPttRightControllerToggle.checked = MoveCenterTabController.pttRightControllerEnabled
         }
 
         Connections {
@@ -418,18 +340,6 @@ MyStackViewPage {
                 } else {
                     playspaceModeText.text = "Unknown(" + MoveCenterTabController.trackingUniverse + ")"
                 }
-            }
-            onPttEnabledChanged: {
-                offsetYPttEnabledToggle.checked = MoveCenterTabController.pttEnabled
-            }
-            onPttActiveChanged: {
-
-            }
-            onPttLeftControllerEnabledChanged: {
-                offsetYPttLeftControllerToggle.checked = MoveCenterTabController.pttLeftControllerEnabled
-            }
-            onPttRightControllerEnabledChanged: {
-                offsetYPttRightControllerToggle.checked = MoveCenterTabController.pttRightControllerEnabled
             }
         }
 

--- a/bin/win64/res/qml/RootPage.qml
+++ b/bin/win64/res/qml/RootPage.qml
@@ -101,6 +101,17 @@ MyStackViewPage {
                    }
 
                    MyPushButton {
+                       id: accessibilityButton
+                       activationSoundEnabled: false
+                       text: "Accessibility"
+                       Layout.fillWidth: true
+                       onClicked: {
+                           MyResources.playFocusChangedSound()
+                           mainView.push(accessibilityPage)
+                       }
+                   }
+
+                   MyPushButton {
                        id: statisticsButton
                        activationSoundEnabled: false
                        text: "Statistics"

--- a/bin/win64/res/qml/mainwidget.qml
+++ b/bin/win64/res/qml/mainwidget.qml
@@ -58,6 +58,11 @@ Rectangle {
         visible: false
     }
 
+    property AccessibilityPage accessibilityPage: AccessibilityPage {
+        stackView: mainView
+        visible: false
+    }
+
     StackView {
         id: mainView
         anchors.fill: parent

--- a/installer/uninstallFiles.list
+++ b/installer/uninstallFiles.list
@@ -417,6 +417,7 @@ Delete $INSTDIR\res\qml\speaker_on.svg
 Delete $INSTDIR\res\qml\StatisticsPage.qml
 Delete $INSTDIR\res\qml\SteamVRPage.qml
 Delete $INSTDIR\res\qml\UtilitiesPage.qml
+Delete $INSTDIR\res\qml\AccessibilityPage.qml
 Delete $INSTDIR\res\thumbicon.png
 Delete $INSTDIR\restartvrserver.bat
 Delete $INSTDIR\startdesktopmode.bat

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -114,6 +114,7 @@ void OverlayController::Init(QQmlEngine* qmlEngine) {
 	settingsTabController.initStage1();
 	reviveTabController.initStage1(settingsTabController.forceRevivePage());
 	utilitiesTabController.initStage1();
+	accessibilityTabController.initStage1();
 
 	// Set qml context
 	qmlEngine->rootContext()->setContextProperty("applicationVersion", getVersionString());
@@ -167,6 +168,11 @@ void OverlayController::Init(QQmlEngine* qmlEngine) {
 	});
 	qmlRegisterSingletonType<SteamVRTabController>("matzman666.advsettings", 1, 0, "UtilitiesTabController", [](QQmlEngine*, QJSEngine*) {
 		QObject* obj = &getInstance()->utilitiesTabController;
+		QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+		return obj;
+	});
+	qmlRegisterSingletonType<SteamVRTabController>("matzman666.advsettings", 1, 0, "AccessibilityTabController", [](QQmlEngine*, QJSEngine*) {
+		QObject* obj = &getInstance()->accessibilityTabController;
 		QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
 		return obj;
 	});
@@ -255,6 +261,7 @@ void OverlayController::SetWidget(QQuickItem* quickItem, const std::string& name
 	settingsTabController.initStage2(this, m_pWindow.get());
 	reviveTabController.initStage2(this, m_pWindow.get());
 	utilitiesTabController.initStage2(this, m_pWindow.get());
+	accessibilityTabController.initStage2(this, m_pWindow.get());
 }
 
 
@@ -298,7 +305,7 @@ void OverlayController::OnTimeoutPumpEvents() {
 			break;
 		}
 	}*/
-	
+
 	vr::TrackedDevicePose_t devicePoses[vr::k_unMaxTrackedDeviceCount];
 	vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0.0f, devicePoses, vr::k_unMaxTrackedDeviceCount);
 	fixFloorTabController.eventLoopTick(devicePoses);
@@ -310,6 +317,7 @@ void OverlayController::OnTimeoutPumpEvents() {
 	reviveTabController.eventLoopTick();
 	audioTabController.eventLoopTick();
 	utilitiesTabController.eventLoopTick();
+	accessibilityTabController.eventLoopTick(vr::VRCompositor()->GetTrackingSpace());
 
 	vr::VREvent_t vrEvent;
 	while (vr::VROverlay()->PollNextOverlayEvent(m_ulOverlayHandle, &vrEvent, sizeof(vrEvent))) {

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -31,6 +31,7 @@
 #include "tabcontrollers/SettingsTabController.h"
 #include "tabcontrollers/ReviveTabController.h"
 #include "tabcontrollers/UtilitiesTabController.h"
+#include "tabcontrollers/AccessibilityTabController.h"
 
 
 
@@ -78,6 +79,7 @@ public: // I know it's an ugly hack to make them public to enable external acces
 	SettingsTabController settingsTabController;
 	ReviveTabController reviveTabController;
 	UtilitiesTabController utilitiesTabController;
+	AccessibilityTabController accessibilityTabController;
 
 private:
     OverlayController(bool desktopMode, bool noSound) : QObject(), desktopMode(desktopMode), noSound(noSound) {}

--- a/src/tabcontrollers/AccessibilityTabController.cpp
+++ b/src/tabcontrollers/AccessibilityTabController.cpp
@@ -1,0 +1,97 @@
+#include "AccessibilityTabController.h"
+#include <QQuickWindow>
+#include "../overlaycontroller.h"
+
+// application namespace
+namespace advsettings {
+
+void AccessibilityTabController::initStage1() {
+  setTrackingUniverse(vr::VRCompositor()->GetTrackingSpace());
+  auto settings = OverlayController::appSettings();
+  settings->beginGroup(getSettingsName());
+  auto value = settings->value("heightOffset", m_heightOffset);
+  settings->endGroup();
+  if (value.isValid() && !value.isNull()) {
+    m_heightOffset = value.toFloat();
+    emit heightOffsetChanged(m_heightOffset);
+  }
+
+  reloadPttConfig();
+}
+
+void AccessibilityTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
+  this->parent = parent;
+  this->widget = widget;
+}
+
+void AccessibilityTabController::setTrackingUniverse(int value) {
+  if (m_trackingUniverse != value) {
+    reset();
+    m_trackingUniverse = value;
+  }
+}
+
+float AccessibilityTabController::heightOffset() const {
+  return m_heightOffset;
+}
+
+void AccessibilityTabController::setHeightOffset(float value, bool notify) {
+  if (m_heightOffset != value) {
+    modHeightOffset(value - m_heightOffset, notify);
+  }
+}
+
+void AccessibilityTabController::modHeightOffset(float value, bool notify) {
+  parent->AddOffsetToUniverseCenter((vr::TrackingUniverseOrigin)m_trackingUniverse, 1, -value, false);
+  m_heightOffset += value;
+  auto settings = OverlayController::appSettings();
+  settings->beginGroup(getSettingsName());
+  settings->setValue("heightOffset", m_heightOffset);
+  settings->endGroup();
+  settings->sync();
+  if (notify) {
+    emit heightOffsetChanged(m_heightOffset);
+  }
+}
+
+
+void AccessibilityTabController::onPttStart() {
+  m_toggleHeightOffset = m_heightOffset;
+  parent->AddOffsetToUniverseCenter((vr::TrackingUniverseOrigin)m_trackingUniverse, 1, m_toggleHeightOffset, false);
+}
+
+void AccessibilityTabController::onPttStop() {
+  parent->AddOffsetToUniverseCenter((vr::TrackingUniverseOrigin)m_trackingUniverse, 1, -m_toggleHeightOffset, false);
+}
+
+void AccessibilityTabController::onPttDisabled() {
+  if (pttActive()) {
+    stopPtt();
+  }
+  m_toggleHeightOffset = 0;
+}
+
+void AccessibilityTabController::reset() {
+  std::lock_guard<std::recursive_mutex> lock(eventLoopMutex);
+  vr::VRChaperoneSetup()->RevertWorkingCopy();
+  parent->AddOffsetToUniverseCenter((vr::TrackingUniverseOrigin)m_trackingUniverse, 1, m_heightOffset, false, false);
+  vr::VRChaperoneSetup()->CommitWorkingCopy(vr::EChaperoneConfigFile_Live);
+  m_heightOffset = 0.0f;
+  emit heightOffsetChanged(m_heightOffset);
+}
+
+void AccessibilityTabController::eventLoopTick(vr::ETrackingUniverseOrigin universe) {
+  if (!eventLoopMutex.try_lock()) {
+    return;
+  }
+  if (settingsUpdateCounter >= 50) {
+    setTrackingUniverse((int)universe);
+    settingsUpdateCounter = 0;
+  } else {
+    settingsUpdateCounter++;
+  }
+  checkPttStatus();
+  eventLoopMutex.unlock();
+}
+
+} // namespace advconfig

--- a/src/tabcontrollers/AccessibilityTabController.h
+++ b/src/tabcontrollers/AccessibilityTabController.h
@@ -1,0 +1,50 @@
+
+#pragma once
+
+#include "PttController.h"
+
+class QQuickWindow;
+// application namespace
+namespace advsettings {
+
+// forward declaration
+class OverlayController;
+
+
+class AccessibilityTabController : public PttController {
+  Q_OBJECT
+  Q_PROPERTY(float heightOffset READ heightOffset WRITE setHeightOffset NOTIFY heightOffsetChanged)
+
+private:
+  OverlayController* parent;
+  QQuickWindow* widget;
+
+  int m_trackingUniverse = (int)vr::TrackingUniverseStanding;
+  float m_heightOffset = 0.0f;
+  float m_toggleHeightOffset = 0.0f;
+
+  unsigned settingsUpdateCounter = 0;
+
+  QString getSettingsName() override { return "accessibilitySettings"; }
+  void onPttStart() override;
+  void onPttStop() override;
+  void onPttDisabled() override;
+
+public:
+  void initStage1();
+  void initStage2(OverlayController* parent, QQuickWindow* widget);
+  void eventLoopTick(vr::ETrackingUniverseOrigin universe);
+
+  float heightOffset() const;
+
+public slots:
+  void setTrackingUniverse(int value);
+  void setHeightOffset(float value, bool notify = true);
+  void modHeightOffset(float value, bool notify = true);
+  void reset();
+
+signals:
+  void heightOffsetChanged(float value);
+};
+
+} // namespace advsettings

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -1,7 +1,8 @@
 
 #pragma once
 
-#include "PttController.h"
+#include <QObject>
+#include <openvr.h>
 
 class QQuickWindow;
 // application namespace
@@ -11,7 +12,7 @@ namespace advsettings {
 class OverlayController;
 
 
-class MoveCenterTabController : public PttController {
+class MoveCenterTabController : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(int trackingUniverse READ trackingUniverse WRITE setTrackingUniverse NOTIFY trackingUniverseChanged)
 	Q_PROPERTY(float offsetX READ offsetX WRITE setOffsetX NOTIFY offsetXChanged)
@@ -27,17 +28,11 @@ private:
 	int m_trackingUniverse = (int)vr::TrackingUniverseStanding;
 	float m_offsetX = 0.0f;
 	float m_offsetY = 0.0f;
-	float m_toggleOffsetY = 0.0f;
 	float m_offsetZ = 0.0f;
 	int m_rotation = 0;
 	bool m_adjustChaperone = true;
 
 	unsigned settingsUpdateCounter = 0;
-
-	QString getSettingsName() override { return "playspaceSettings"; }
-	void onPttStart() override;
-	void onPttStop() override;
-	void onPttDisabled() override;
 
 public:
 	void initStage1();


### PR DESCRIPTION
Package it as a new height adjustment tool. Height offset is saved and can be set via slider. Playspace page and MoveCenterTabController have been reverted to 6c7240f.

Debatable decision I made while implementing—the slider is artificially limiting users from 0-1.5m. I thought this hotkey should be limited to actual accessibility use cases since it's being explicitly packaged that way instead of being stuffed into the Playspage page. And I couldn't think of any situations where you'd need to make yourself shorter with a push-to-toggle on the height loss to play a game, or where somebody would need more than 1.5m as a boost. Both limits are easy to change if there's a need, since they're just set by the range of the slider.