### PR TITLE
Fixed rotation away from the origin

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -445,9 +445,9 @@ void OverlayController::RotateUniverseCenter(vr::ETrackingUniverseOrigin univers
 		vr::HmdMatrix34_t newPos;
 		utils::initRotationMatrix(rotMat, 1, yAngle);
 		utils::matMul33(newPos, rotMat, curPos);
-		newPos.m[0][3] = curPos.m[0][3];
+		newPos.m[0][3] = std::cos(yAngle) * curPos.m[0][3] + std::sin(yAngle) * curPos.m[2][3];
 		newPos.m[1][3] = curPos.m[1][3];
-		newPos.m[2][3] = curPos.m[2][3];
+		newPos.m[2][3] = std::cos(yAngle) * curPos.m[2][3] - std::sin(yAngle) * curPos.m[0][3];
 		if (universe == vr::TrackingUniverseStanding) {
 			vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(&newPos);
 		} else {


### PR DESCRIPTION
Rotation when away from the origin is now applied to the current position rather than rotating about the origin.

I was playing with the position and rotation offsets using this great tool and noticed that if I rotated when not at the origin my position would also change. This PR fixes that similar to how the X and Z position offsets are adjusted for angles other than 0 deg. (I use it with driver_null instead of a real HMD but I don't think that should effect anything.)