### PR TITLE
SteamVRPage: Always-on reprojection does not require a restart.

### DIFF
--- a/bin/win64/res/qml/SteamVRPage.qml
+++ b/bin/win64/res/qml/SteamVRPage.qml
@@ -167,7 +167,7 @@ MyStackViewPage {
 
         MyToggleButton {
             id: steamvrForceReprojectionToggle
-            text: "Enable Always-on Reprojection*"
+            text: "Enable Always-on Reprojection"
             onCheckedChanged: {
                 SteamVRTabController.setForceReprojection(this.checked, false)
             }


### PR DESCRIPTION
Nothing in SteamVR indicates a restart is necessary and I've been switching this on/off in the settings for months without restarting.